### PR TITLE
Refactor hook example generation logic

### DIFF
--- a/extract-wp-hooks.php
+++ b/extract-wp-hooks.php
@@ -473,7 +473,7 @@ foreach ( $filters as $hook => $data ) {
 				}
 			}
 		}
-		
+
 		// Complete the function signature with parameters
 		$signature .= $param_string . ' ) {';
 		$signature .= PHP_EOL . '    // Your code here.';
@@ -483,7 +483,7 @@ foreach ( $filters as $hook => $data ) {
 		$signature .= PHP_EOL . '}';
 
 		// Add the hook registration line
-		$signature .= PHP_EOL . $hook_function . '( \'' . $hook . '\', \'prefixed_' . $hook_type . '_callback\'';
+		$signature .= PHP_EOL . $hook_function . "( '{$hook}', 'prefixed_{$hook_type}_callback'";
 
 		if ( $count > 1 ) {
 			$signature .= ', 10, ' . $count;


### PR DESCRIPTION
This is probably more a matter of taste, so please feel free to close this if it doesn't match your preference.

Changes in this PR would generate non-closure example callbacks.

#### Before

```php
add_filter(
    'activitypub_extract_mentions',
    function (
        array $mentions,
        string $content,
        WP_Post $post
    ) {
        // Your code here
        return $mentions;
    },
    10,
    3
);
```

#### After
```php
function prefixed_filter_callback( array $mentions, string $content, WP_Post $post ) {
    // Your code here.
    return $mentions;
}
add_filter( 'activitypub_extract_mentions', 'prefixed_filter_callback', 10, 3 );
```