### PR TITLE
Update prefixed example style to use inline hook registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 wiki
+.phpunit.cache

--- a/class-wphookextractor.php
+++ b/class-wphookextractor.php
@@ -619,8 +619,7 @@ class WpHookExtractor {
 						} elseif ( count( $signature_params ) === 1 ) {
 							$function_signature .= ' ' . $signature_params[0] . ' ) {';
 						} else {
-							$function_signature .= "\n    ";
-							$function_signature .= implode( ",\n    ", $signature_params ) . "\n) {";
+							$function_signature .= ' ' . implode( ', ', $signature_params ) . ' ) {';
 						}
 						$function_signature .= "\n    // Your code here.";
 						if ( 'action' !== $hook_type && ! empty( $signature_params[0] ) ) {
@@ -629,11 +628,14 @@ class WpHookExtractor {
 						}
 						$function_signature .= "\n}";
 
-						$signature = $hook_function . "(\n   '{$hook}',\n    '{$callback_name}'";
+						// Add hook registration on a single line below the function.
+						$hook_registration = $hook_function . "( '{$hook}', '{$callback_name}'";
 						if ( $consistent_param_count > 1 ) {
-							$signature .= ",\n    10,\n    {$consistent_param_count}";
+							$hook_registration .= ", 10, {$consistent_param_count}";
 						}
-						$signature .= "\n);\n\n{$function_signature}";
+						$hook_registration .= " );";
+
+						$signature = "{$function_signature}\n{$hook_registration}";
 						break;
 					default:
 						$signature = $hook_function . '(' . PHP_EOL . '   \'' . $hook . '\',' . PHP_EOL . '    function(';
@@ -675,8 +677,7 @@ class WpHookExtractor {
 						} elseif ( count( $signature_params ) === 1 ) {
 							$function_signature .= ' ' . $signature_params[0] . ' ) {';
 						} else {
-							$function_signature .= "\n    ";
-							$function_signature .= implode( ",\n    ", $signature_params ) . "\n) {";
+							$function_signature .= ' ' . implode( ', ', $signature_params ) . ' ) {';
 						}
 						$function_signature .= "\n    // Your code here.";
 						if ( 'action' !== $hook_type && ! empty( $signature_params[0] ) ) {
@@ -685,11 +686,14 @@ class WpHookExtractor {
 						}
 						$function_signature .= "\n}";
 
-						$signature = $hook_function . "(\n   '{$hook}',\n    '{$callback_name}'";
+						// Add hook registration on a single line below the function.
+						$hook_registration = $hook_function . "( '{$hook}', '{$callback_name}'";
 						if ( $consistent_param_count > 1 ) {
-							$signature .= ",\n    10,\n    {$consistent_param_count}";
+							$hook_registration .= ", 10, {$consistent_param_count}";
 						}
-						$signature .= "\n);\n\n{$function_signature}";
+						$hook_registration .= " );";
+
+						$signature = "{$function_signature}\n{$hook_registration}";
 						break;
 					default:
 						$signature = $hook_function . '(' . PHP_EOL . '   \'' . $hook . '\',' . PHP_EOL . '    function(';

--- a/tests/fixtures/expected/example_prefixed_0_params.md
+++ b/tests/fixtures/expected/example_prefixed_0_params.md
@@ -1,13 +1,9 @@
 ## Auto-generated Example
 
 ```php
-add_action(
-   'zero_param_hook',
-    'my_zero_param_hook_callback'
-);
-
 function my_zero_param_hook_callback() {
     // Your code here.
 }
+add_action( 'zero_param_hook', 'my_zero_param_hook_callback' );
 ```
 

--- a/tests/fixtures/expected/example_prefixed_2_params.md
+++ b/tests/fixtures/expected/example_prefixed_2_params.md
@@ -1,19 +1,10 @@
 ## Auto-generated Example
 
 ```php
-add_filter(
-   'two_param_hook',
-    'my_two_param_hook_callback',
-    10,
-    2
-);
-
-function my_two_param_hook_callback(
-    $first,
-    $second
-) {
+function my_two_param_hook_callback( $first, $second ) {
     // Your code here.
     return $first;
 }
+add_filter( 'two_param_hook', 'my_two_param_hook_callback', 10, 2 );
 ```
 

--- a/tests/fixtures/expected/example_prefixed_3_params.md
+++ b/tests/fixtures/expected/example_prefixed_3_params.md
@@ -1,20 +1,10 @@
 ## Auto-generated Example
 
 ```php
-add_filter(
-   'multi_param_hook',
-    'my_multi_param_hook_callback',
-    10,
-    3
-);
-
-function my_multi_param_hook_callback(
-    $param1,
-    $param2,
-    $extra_data
-) {
+function my_multi_param_hook_callback( $param1, $param2, $extra_data ) {
     // Your code here.
     return $param1;
 }
+add_filter( 'multi_param_hook', 'my_multi_param_hook_callback', 10, 3 );
 ```
 

--- a/tests/fixtures/expected/example_prefixed_action_0_params.md
+++ b/tests/fixtures/expected/example_prefixed_action_0_params.md
@@ -1,13 +1,9 @@
 ## Auto-generated Example
 
 ```php
-add_action(
-   'zero_param_hook',
-    'my_zero_param_hook_callback'
-);
-
 function my_zero_param_hook_callback() {
     // Your code here.
 }
+add_action( 'zero_param_hook', 'my_zero_param_hook_callback' );
 ```
 

--- a/tests/fixtures/expected/example_prefixed_action_1_param.md
+++ b/tests/fixtures/expected/example_prefixed_action_1_param.md
@@ -1,13 +1,9 @@
 ## Auto-generated Example
 
 ```php
-add_action(
-   'one_param_hook',
-    'my_one_param_hook_callback'
-);
-
 function my_one_param_hook_callback( $param1 ) {
     // Your code here.
 }
+add_action( 'one_param_hook', 'my_one_param_hook_callback' );
 ```
 

--- a/tests/fixtures/expected/example_prefixed_action_2_params.md
+++ b/tests/fixtures/expected/example_prefixed_action_2_params.md
@@ -1,18 +1,9 @@
 ## Auto-generated Example
 
 ```php
-add_action(
-   'two_param_action_hook',
-    'my_two_param_action_hook_callback',
-    10,
-    2
-);
-
-function my_two_param_action_hook_callback(
-    $param1,
-    $param2
-) {
+function my_two_param_action_hook_callback( $param1, $param2 ) {
     // Your code here.
 }
+add_action( 'two_param_action_hook', 'my_two_param_action_hook_callback', 10, 2 );
 ```
 

--- a/tests/fixtures/expected/example_prefixed_action_3_params.md
+++ b/tests/fixtures/expected/example_prefixed_action_3_params.md
@@ -1,19 +1,9 @@
 ## Auto-generated Example
 
 ```php
-add_action(
-   'three_param_hook',
-    'my_three_param_hook_callback',
-    10,
-    3
-);
-
-function my_three_param_hook_callback(
-    $param1,
-    $param2,
-    $param3
-) {
+function my_three_param_hook_callback( $param1, $param2, $param3 ) {
     // Your code here.
 }
+add_action( 'three_param_hook', 'my_three_param_hook_callback', 10, 3 );
 ```
 

--- a/tests/fixtures/expected/example_prefixed_complex_params.md
+++ b/tests/fixtures/expected/example_prefixed_complex_params.md
@@ -1,21 +1,11 @@
 ## Auto-generated Example
 
 ```php
-add_filter(
-   'complex_hook',
-    'my_complex_hook_callback',
-    10,
-    3
-);
-
-function my_complex_hook_callback(
-    string $setting,
-    int $user_id,
-    array $options
-) {
+function my_complex_hook_callback( string $setting, int $user_id, array $options ) {
     // Your code here.
     return $setting;
 }
+add_filter( 'complex_hook', 'my_complex_hook_callback', 10, 3 );
 ```
 
 

--- a/tests/fixtures/expected/example_prefixed_complex_params_invalid_comment_position.md
+++ b/tests/fixtures/expected/example_prefixed_complex_params_invalid_comment_position.md
@@ -1,20 +1,10 @@
 ## Auto-generated Example
 
 ```php
-add_filter(
-   'complex_hook_invalid_comment',
-    'my_complex_hook_invalid_comment_callback',
-    10,
-    3
-);
-
-function my_complex_hook_invalid_comment_callback(
-    $setting,
-    $ID,
-    array $string_list
-) {
+function my_complex_hook_invalid_comment_callback( $setting, $ID, array $string_list ) {
     // Your code here.
     return $setting;
 }
+add_filter( 'complex_hook_invalid_comment', 'my_complex_hook_invalid_comment_callback', 10, 3 );
 ```
 

--- a/tests/fixtures/expected/example_prefixed_style.md
+++ b/tests/fixtures/expected/example_prefixed_style.md
@@ -1,14 +1,10 @@
 ## Auto-generated Example
 
 ```php
-add_filter(
-   'simple_hook',
-    'my_simple_hook_callback'
-);
-
 function my_simple_hook_callback( $value ) {
     // Your code here.
     return $value;
 }
+add_filter( 'simple_hook', 'my_simple_hook_callback' );
 ```
 


### PR DESCRIPTION
Style update give prefixed function docs a more classic look.