### PR TITLE
Fix top_headline input interpolation in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ runs:
             "github_blob_url": "$github_blob_url",
             "exclude_dirs": [$exclude_dirs],
             "example_style": "${{ inputs.example-style }}",
-            "top_headline": ${!inputs.top-headline:-false},
+            "top_headline": ${{ inputs.top-headline }},
             "ignore_filter": [$ignore_filters]$([ -n "${{ inputs.ignore-regex }}" ] && echo ',
             "ignore_regex": "${{ inputs.ignore-regex }}"' || echo '')$([ "${{ inputs.section }}" != "file" ] && echo ',
             "section": "${{ inputs.section }}"' || echo '')


### PR DESCRIPTION
It looks like dc96219bd47906ff5eaf8a90e4781001873a2602 may have broken config file creation from action inputs.
See https://github.com/Automattic/wordpress-activitypub/actions/runs/16746462157/job/47406068485


#### Proposed Changes
* Replaces shell parameter expansion with GitHub Actions expression syntax for the 'top_headline' input, ensuring correct value assignment.