### PR TITLE
Add support for deprecated hooks

### DIFF
--- a/tests/fixtures/deprecated_hooks.php
+++ b/tests/fixtures/deprecated_hooks.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Test file for deprecated hooks.
+ */
+
+/**
+ * Deprecated action hook.
+ *
+ * @deprecated 7.5.0 Use "activitypub_handled_follow" instead.
+ *
+ * @param string $actor    The URL of the actor.
+ * @param array  $activity The activity data.
+ * @param int    $user_id  The user ID.
+ */
+\do_action_deprecated( 'activitypub_followers_post_follow', array( $activity['actor'], $activity, $user_id ), '7.5.0', 'activitypub_handled_follow' );
+
+/**
+ * Deprecated filter hook.
+ *
+ * @deprecated 7.1.0 Please migrate your Followings to the new internal Following structure.
+ *
+ * @param array $items The array of following urls.
+ * @param object $user The user object.
+ */
+$items = \apply_filters_deprecated( 'activitypub_rest_following', array( array(), $user ), '7.1.0', 'Please migrate your Followings to the new internal Following structure.' );
+
+/**
+ * Deprecated hook without replacement.
+ *
+ * @deprecated 8.0.0
+ *
+ * @param string $data Some data.
+ */
+\do_action_deprecated( 'old_legacy_hook', array( $data ), '8.0.0' );
+
+/**
+ * Deprecated hook without version or replacement.
+ *
+ * @deprecated
+ *
+ * @param int $id Some ID.
+ */
+\do_action_deprecated( 'very_old_hook', array( $id ) );

--- a/tests/fixtures/expected/deprecated_action_hook.md
+++ b/tests/fixtures/expected/deprecated_action_hook.md
@@ -1,0 +1,40 @@
+> **DEPRECATED**
+> This hook was deprecated in version 7.5.0.
+> Use `activitypub_handled_follow` instead.
+
+
+Deprecated action hook.
+
+## Auto-generated Example
+
+```php
+add_action(
+   'activitypub_followers_post_follow',
+    function(
+        string $actor,
+        array $activity,
+        int $user_id
+    ) {
+        // Your code here.
+    },
+    10,
+    3
+);
+```
+
+## Parameters
+
+- *`string`* `$actor` The URL of the actor.
+- *`array`* `$activity` The activity data.
+- *`int`* `$user_id` The user ID.
+
+## Files
+
+- [deprecated_hooks.php:16](https://github.com/test/repo/blob/main/deprecated_hooks.php#L16)
+```php
+\do_action_deprecated( 'activitypub_followers_post_follow', array( $activity['actor'], $activity, $user_id ), '7.5.0', 'activitypub_handled_follow' )
+```
+
+
+
+[← All Hooks](Hooks)

--- a/tests/fixtures/expected/deprecated_filter_hook.md
+++ b/tests/fixtures/expected/deprecated_filter_hook.md
@@ -1,0 +1,41 @@
+> **DEPRECATED**
+> This hook was deprecated in version 7.1.0.
+> Please migrate your Followings to the new internal Following structure.
+
+
+Deprecated filter hook.
+
+## Auto-generated Example
+
+```php
+add_filter(
+   'activitypub_rest_following',
+    function(
+        array $items,
+        object $user,
+        string $please_migrate_your_followings_to_the_new_internal_following_structure_
+    ) {
+        // Your code here.
+        return $items;
+    },
+    10,
+    3
+);
+```
+
+## Parameters
+
+- *`array`* `$items` The array of following urls.
+- *`object`* `$user` The user object.
+- *`string`* `$please_migrate_your_followings_to_the_new_internal_following_structure_`
+
+## Files
+
+- [deprecated_hooks.php:26](https://github.com/test/repo/blob/main/deprecated_hooks.php#L26)
+```php
+\apply_filters_deprecated( 'activitypub_rest_following', array( array(), $user ), '7.1.0', 'Please migrate your Followings to the new internal Following structure.' )
+```
+
+
+
+[← All Hooks](Hooks)

--- a/tests/fixtures/expected/deprecated_hook_no_replacement.md
+++ b/tests/fixtures/expected/deprecated_hook_no_replacement.md
@@ -1,0 +1,37 @@
+> **DEPRECATED**
+> This hook was deprecated in version 8.0.0.
+
+
+Deprecated hook without replacement.
+
+## Auto-generated Example
+
+```php
+add_action(
+   'old_legacy_hook',
+    function(
+        string $data,
+        string $8_0_0
+    ) {
+        // Your code here.
+    },
+    10,
+    2
+);
+```
+
+## Parameters
+
+- *`string`* `$data` Some data.
+- *`string`* `$8_0_0`
+
+## Files
+
+- [deprecated_hooks.php:35](https://github.com/test/repo/blob/main/deprecated_hooks.php#L35)
+```php
+\do_action_deprecated( 'old_legacy_hook', array( $data ), '8.0.0' )
+```
+
+
+
+[← All Hooks](Hooks)

--- a/tests/fixtures/expected/deprecated_hook_no_version.md
+++ b/tests/fixtures/expected/deprecated_hook_no_version.md
@@ -1,0 +1,30 @@
+> **DEPRECATED**
+
+
+Deprecated hook without version or replacement.
+
+## Auto-generated Example
+
+```php
+add_action(
+   'very_old_hook',
+    function( int $id ) {
+        // Your code here.
+    }
+);
+```
+
+## Parameters
+
+- *`int`* `$id` Some ID.
+
+## Files
+
+- [deprecated_hooks.php:44](https://github.com/test/repo/blob/main/deprecated_hooks.php#L44)
+```php
+\do_action_deprecated( 'very_old_hook', array( $id ) )
+```
+
+
+
+[← All Hooks](Hooks)

--- a/tests/fixtures/expected/deprecated_hooks_index.md
+++ b/tests/fixtures/expected/deprecated_hooks_index.md
@@ -1,0 +1,7 @@
+
+## deprecated_hooks.php
+
+- [~~`activitypub_followers_post_follow`~~](activitypub_followers_post_follow) **DEPRECATED** Use `activitypub_handled_follow` instead
+- [~~`activitypub_rest_following`~~](activitypub_rest_following) **DEPRECATED** Please migrate your Followings to the new internal Following structure.
+- [~~`old_legacy_hook`~~](old_legacy_hook) **DEPRECATED**
+- [~~`very_old_hook`~~](very_old_hook) **DEPRECATED**


### PR DESCRIPTION
### Suggested Changes
- Detects deprecated hooks with version and replacement information.
- Generates deprecation warnings in documentation with version info and replacement string.
- Shows deprecated hooks with strikethrough formatting in index.
- Adds tests and documents expected output.