### PR TITLE
Fix parsing of multiple identical tags in docblocks

### DIFF
--- a/class-wphookextractor.php
+++ b/class-wphookextractor.php
@@ -351,6 +351,10 @@ class WpHookExtractor {
 				}
 				// If this tag was already parsed, make its value an array.
 				if ( isset( $tags[ $tag_name ] ) ) {
+					// Convert to array format if not already (first occurrence was stored as string).
+					if ( ! is_array( $tags[ $tag_name ] ) ) {
+						$tags[ $tag_name ] = array( array( $tags[ $tag_name ] ) );
+					}
 					$tags[ $tag_name ][] = array( $tag_value );
 				} else {
 					$tags[ $tag_name ] = $tag_value;
@@ -786,12 +790,16 @@ class WpHookExtractor {
 
 						// Generate the function documentation.
 						if ( $this->config['autoexample_phpdoc'] ) {
+							$returns_for_docs = $data['returns'] ?? '';
+							if ( is_array( $returns_for_docs ) ) {
+								$returns_for_docs = $returns_for_docs[0][0];
+							}
 							$function_docs = $this->generate_function_docs(
 								$hook,
 								$hook_type,
 								$param_docs,
 								$data['comment'] ?? '',
-								$data['returns'] ?? '',
+								$returns_for_docs,
 								$callback_name
 							);
 
@@ -828,7 +836,8 @@ class WpHookExtractor {
 
 			if ( ! empty( $data['returns'] ) ) {
 				$returns_content = "## Returns\n";
-				$p = preg_split( '/ +/', $data['returns'], 2 );
+				$returns_value = is_array( $data['returns'] ) ? $data['returns'][0][0] : $data['returns'];
+				$p = preg_split( '/ +/', $returns_value, 2 );
 				$p[0] = $this->maybe_prefix_namespace( $p[0] );
 				if ( ! isset( $p[1] ) ) {
 					$p[1] = '';

--- a/tests/ArrayTagsTest.php
+++ b/tests/ArrayTagsTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests for parsing docblocks with multiple occurrences of the same tag.
+ *
+ * @see https://github.com/akirk/extract-wp-hooks/issues/23
+ */
+class ArrayTagsTest extends WpHookExtractor_Testcase {
+
+	/**
+	 * Test that multiple @type tags are parsed correctly.
+	 *
+	 * This is the main issue reported in #23: WordPress documentation standards
+	 * allow documenting array parameters with multiple @type tags.
+	 */
+	public function test_multiple_type_tags_extraction() {
+		$file_path = __DIR__ . '/fixtures/multiple_type_tags.php';
+		$extractor = new WpHookExtractor();
+		$hooks = $extractor->extract_hooks_from_file( $file_path );
+
+		$this->assertArrayHasKey( 'multiple_type_tags_hook', $hooks );
+
+		$hook = $hooks['multiple_type_tags_hook'];
+		$this->assertEquals( 'apply_filters', $hook['type'] );
+
+		// Verify all 6 @type tags are extracted.
+		$this->assertArrayHasKey( 'types', $hook );
+		$this->assertIsArray( $hook['types'] );
+		$this->assertCount( 6, $hook['types'] );
+
+		// Verify specific type entries.
+		$this->assertStringContainsString( '$name', $hook['types'][0][0] );
+		$this->assertStringContainsString( '$slug', $hook['types'][1][0] );
+		$this->assertStringContainsString( '$parent', $hook['types'][2][0] );
+		$this->assertStringContainsString( '$taxonomy', $hook['types'][3][0] );
+		$this->assertStringContainsString( '$level', $hook['types'][4][0] );
+		$this->assertStringContainsString( '$location', $hook['types'][5][0] );
+	}
+
+	/**
+	 * Test that documentation generation works with multiple @type tags.
+	 */
+	public function test_multiple_type_tags_documentation() {
+		$file_path = __DIR__ . '/fixtures/multiple_type_tags.php';
+		$extractor = new WpHookExtractor();
+		$hooks = $extractor->extract_hooks_from_file( $file_path );
+
+		$github_blob_url = 'https://github.com/test/repo/blob/main/';
+		$documentation = $extractor->create_documentation_content( $hooks, $github_blob_url );
+
+		$this->assertArrayHasKey( 'hooks', $documentation );
+		$this->assertArrayHasKey( 'multiple_type_tags_hook', $documentation['hooks'] );
+	}
+
+	/**
+	 * Test that multiple @return tags are parsed without crashing.
+	 *
+	 * While unusual, multiple @return tags should not cause a fatal error.
+	 */
+	public function test_multiple_return_tags_extraction() {
+		$file_path = __DIR__ . '/fixtures/multiple_return_tags.php';
+		$extractor = new WpHookExtractor();
+		$hooks = $extractor->extract_hooks_from_file( $file_path );
+
+		$this->assertArrayHasKey( 'multiple_return_tags_hook', $hooks );
+
+		$hook = $hooks['multiple_return_tags_hook'];
+		$this->assertEquals( 'apply_filters', $hook['type'] );
+
+		// Verify @return is extracted (as array when multiple).
+		$this->assertArrayHasKey( 'returns', $hook );
+		$this->assertIsArray( $hook['returns'] );
+		$this->assertCount( 2, $hook['returns'] );
+
+		// Verify both return types are captured.
+		$this->assertStringContainsString( 'string', $hook['returns'][0][0] );
+		$this->assertStringContainsString( 'int', $hook['returns'][1][0] );
+	}
+
+	/**
+	 * Test that documentation generation works with multiple @return tags.
+	 */
+	public function test_multiple_return_tags_documentation() {
+		$file_path = __DIR__ . '/fixtures/multiple_return_tags.php';
+		$extractor = new WpHookExtractor();
+		$hooks = $extractor->extract_hooks_from_file( $file_path );
+
+		$github_blob_url = 'https://github.com/test/repo/blob/main/';
+		$documentation = $extractor->create_documentation_content( $hooks, $github_blob_url );
+
+		$this->assertArrayHasKey( 'hooks', $documentation );
+		$this->assertArrayHasKey( 'multiple_return_tags_hook', $documentation['hooks'] );
+
+		// Verify the returns section uses the first return type.
+		$hook_doc = $documentation['hooks']['multiple_return_tags_hook'];
+		$this->assertArrayHasKey( 'returns', $hook_doc );
+		$this->assertStringContainsString( 'string', $hook_doc['returns'] );
+	}
+
+	/**
+	 * Test that single @return tag remains a string (backwards compatibility).
+	 */
+	public function test_single_return_tag_is_string() {
+		$file_path = __DIR__ . '/fixtures/docblock_with_example.php';
+		$extractor = new WpHookExtractor();
+		$hooks = $extractor->extract_hooks_from_file( $file_path );
+
+		$this->assertArrayHasKey( 'user_data_filter', $hooks );
+
+		$hook = $hooks['user_data_filter'];
+		$this->assertArrayHasKey( 'returns', $hook );
+		$this->assertIsString( $hook['returns'] );
+		$this->assertEquals( 'array Modified user data', $hook['returns'] );
+	}
+
+	/**
+	 * Test that single @since tag remains a string (backwards compatibility).
+	 */
+	public function test_single_since_tag_is_string() {
+		$file_path = __DIR__ . '/fixtures/simple_filter.php';
+		$extractor = new WpHookExtractor();
+		$hooks = $extractor->extract_hooks_from_file( $file_path );
+
+		$this->assertArrayHasKey( 'simple_hook', $hooks );
+
+		$hook = $hooks['simple_hook'];
+		if ( isset( $hook['sinces'] ) ) {
+			// If there's only one @since, it should be a string.
+			// If the fixture has multiple, it would be an array.
+			$this->assertTrue(
+				is_string( $hook['sinces'] ) || is_array( $hook['sinces'] ),
+				'sinces should be either string or array'
+			);
+		}
+	}
+}

--- a/tests/fixtures/multiple_return_tags.php
+++ b/tests/fixtures/multiple_return_tags.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Filter with multiple return tags (unusual but should not crash).
+ *
+ * @param mixed $value The value to filter.
+ * @return string When the value is a string.
+ * @return int When the value is numeric.
+ */
+$result = apply_filters( 'multiple_return_tags_hook', $value );

--- a/tests/fixtures/multiple_type_tags.php
+++ b/tests/fixtures/multiple_type_tags.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Filter term arguments before creating the term.
+ *
+ * @since 0.1.0
+ *
+ * @param array $args {
+ *     Term arguments.
+ *
+ *     @type string                $name      Term name.
+ *     @type string                $slug      Term slug.
+ *     @type int                   $parent    Parent term ID.
+ *     @type string                $taxonomy  Taxonomy name.
+ *     @type int                   $level     Hierarchy level (1-6).
+ *     @type array<string, string> $location  Full location data array.
+ * }
+ */
+$term_args = apply_filters(
+	'multiple_type_tags_hook',
+	array(
+		'name'     => $name,
+		'slug'     => $slug,
+		'parent'   => $parent_id,
+		'taxonomy' => $taxonomy,
+		'level'    => $level,
+		'location' => $location,
+	)
+);


### PR DESCRIPTION
## Summary

- Fixes issue where docblocks with multiple `@type` tags would cause the second tag to overwrite the data structure instead of appending to it
- Handles edge case of multiple `@return` tags in documentation generation
- Adds unit tests for multiple `@type` and `@return` tag scenarios

Fixes #23

## Test plan

- [x] Run `vendor/bin/phpunit tests/ArrayTagsTest.php` - all 6 new tests pass
- [x] Run `vendor/bin/phpunit` - all 48 tests pass
- [x] Run `vendor/bin/phpcs` - no style violations