### PR TITLE
Skip array parameter block content from main description

### DIFF
--- a/class-wphookextractor.php
+++ b/class-wphookextractor.php
@@ -252,6 +252,7 @@ class WpHookExtractor {
 				break;
 		}
 		$inside_code = false;
+		$inside_param_block = false;
 		$current_example = null;
 		$example_content = '';
 		$code_block_indent = null;
@@ -332,8 +333,26 @@ class WpHookExtractor {
 				continue;
 			}
 
+			// Handle lines inside @param array blocks (WordPress array parameter syntax).
+			if ( $inside_param_block ) {
+				// Check for closing brace.
+				if ( preg_match( '#^\s*\}\s*$#', $line ) ) {
+					$inside_param_block = false;
+					continue;
+				}
+				// Parse @type tags inside the block, skip other content.
+				if ( ! preg_match( '#^@#', $line ) ) {
+					continue;
+				}
+			}
+
 			if ( preg_match( '#@(param)(.*)#', $line, $matches ) ) {
 				$tag_value = \trim( $matches[2] );
+
+				// Check if this starts an array parameter block (ends with {).
+				if ( preg_match( '#\{\s*$#', $tag_value ) ) {
+					$inside_param_block = true;
+				}
 
 				// If this tag was already parsed, make its value an array.
 				if ( isset( $tags['params'] ) ) {


### PR DESCRIPTION
## Summary

WordPress array parameter documentation uses `{ }` blocks after `@param`:

```php
@param array $args {
    Description of array members.
    @type string $name Name.
}
```

Lines inside this block (except `@type` tags) were being added to the main hook description, causing "Term arguments." and `}` to appear in the wrong place.

This fix tracks when we're inside such a block and skips non-tag lines.

## Before

```
Filter term arguments before creating the term.

Term arguments.

}

## Auto-generated Example
```

## After

```
Filter term arguments before creating the term.

## Auto-generated Example
```

See [multiple_type_tags_hook](https://github.com/akirk/extract-wp-hooks/wiki/multiple_type_tags_hook) for a live example.

## Test plan

- [x] Run `vendor/bin/phpunit` - all 48 tests pass
- [x] Run `vendor/bin/phpcs` - no style violations