### PR TITLE
Clean up array parameter output in documentation

### DIFF
--- a/class-wphookextractor.php
+++ b/class-wphookextractor.php
@@ -145,7 +145,7 @@ class WpHookExtractor {
 		$vars = array( '' );
 		$signature = $tokens[ $i ][1];
 		$line = $tokens[ $i ][2];
-		$search_window = 50;
+		$search_window = 100;
 		for ( $j = $i + 1; $j < $i + $search_window; $j++ ) {
 			if ( ! isset( $tokens[ $j ] ) ) {
 				break;
@@ -686,6 +686,11 @@ class WpHookExtractor {
 					// Determine if this parameter should be optional (not used consistently across all files).
 					$is_optional = $i >= $consistent_param_count;
 
+					// Strip trailing { from array parameter descriptions (WordPress documentation style).
+					if ( isset( $p[2] ) ) {
+						$p[2] = rtrim( $p[2], ' {' );
+					}
+
 					if ( 'unknown' === $p[0] ) {
 						$params .= "\n- `{$p[1]}`";
 						if ( $is_optional ) {
@@ -693,12 +698,12 @@ class WpHookExtractor {
 						} else {
 							$signature_params[] = $p[1];
 						}
-						if ( isset( $p[2] ) ) {
+						if ( ! empty( $p[2] ) ) {
 							$params .= ' ' . $p[2];
 						}
 					} else {
 						$params .= "\n- *`{$p[0]}`* `{$p[1]}`";
-						if ( isset( $p[2] ) ) {
+						if ( ! empty( $p[2] ) ) {
 							$params .= ' ' . $p[2];
 						}
 						if ( substr( $p[0], -5 ) === '|null' || $is_optional ) {


### PR DESCRIPTION
## Summary

Follow-up to #26 to further clean up the array parameter documentation output:

- Strip trailing `{` from array parameter descriptions (e.g., `$args {` → `$args`)
- Increase search window from 50 to 100 tokens to capture full array arguments in code snippets
- Don't output empty parameter descriptions

## Example output

```markdown
## Parameters

- *`array`* `$args`
  - *`string`* `$name` Term name.
  - *`string`* `$slug` Term slug.
  - *`int`* `$parent` Parent term ID.
```

See [multiple_type_tags_hook](https://github.com/akirk/extract-wp-hooks/wiki/multiple_type_tags_hook) for a live example.

## Test plan

- [x] Run `vendor/bin/phpunit` - all 48 tests pass
- [x] Run `vendor/bin/phpcs` - no style violations