### PR TITLE
Fix empty string param generating invalid variable name in auto-generated examples

### DIFF
--- a/class-wphookextractor.php
+++ b/class-wphookextractor.php
@@ -722,7 +722,8 @@ class WpHookExtractor {
 							$vars[ $k ] = '$' . preg_replace( '/[^a-z0-9]/', '_', strtolower( trim( $matches[1], '"\'' ) ) );
 						} elseif ( strlen( $var ) - strlen( trim( $var, '"\'' ) ) === 2 ) {
 							$type       = 'string';
-							$vars[ $k ] = '$' . preg_replace( '/[^a-z0-9]/', '_', strtolower( trim( $var, '"\'' ) ) );
+							$trimmed    = preg_replace( '/[^a-z0-9]/', '_', strtolower( trim( $var, '"\'' ) ) );
+							$vars[ $k ] = '$' . ( '' !== $trimmed ? $trimmed : 'value' );
 						} elseif ( is_numeric( $var ) ) {
 							$type       = 'int';
 							$vars[ $k ] = '$int';

--- a/tests/ExampleStyleTest.php
+++ b/tests/ExampleStyleTest.php
@@ -105,6 +105,32 @@ class ExampleStyleTest extends WpHookExtractor_Testcase {
 		$this->assertStringEqualsFileOrWrite( __DIR__ . '/fixtures/expected/example_prefixed_3_params.md', $documentation['hooks']['multi_param_hook']['example'] );
 	}
 
+	public function test_default_example_style_empty_string_param() {
+		$config = array( 'example_style' => 'default' );
+		$extractor = new WpHookExtractor( $config );
+
+		$file_path = __DIR__ . '/fixtures/empty_string_param.php';
+		$hooks = $extractor->extract_hooks_from_file( $file_path );
+
+		$github_blob_url = 'https://github.com/test/repo/blob/main/';
+		$documentation = $extractor->create_documentation_content( $hooks, $github_blob_url );
+
+		$this->assertStringEqualsFileOrWrite( __DIR__ . '/fixtures/expected/example_default_empty_string_param.md', $documentation['hooks']['ai_assistant_ability_instructions']['example'] );
+	}
+
+	public function test_prefixed_example_style_empty_string_param() {
+		$config = array( 'example_style' => 'prefixed' );
+		$extractor = new WpHookExtractor( $config );
+
+		$file_path = __DIR__ . '/fixtures/empty_string_param.php';
+		$hooks = $extractor->extract_hooks_from_file( $file_path );
+
+		$github_blob_url = 'https://github.com/test/repo/blob/main/';
+		$documentation = $extractor->create_documentation_content( $hooks, $github_blob_url );
+
+		$this->assertStringEqualsFileOrWrite( __DIR__ . '/fixtures/expected/example_prefixed_empty_string_param.md', $documentation['hooks']['ai_assistant_ability_instructions']['example'] );
+	}
+
 	public function test_example_style_does_not_affect_existing_examples() {
 		$config = array( 'example_style' => 'prefixed' );
 		$extractor = new WpHookExtractor( $config );

--- a/tests/fixtures/empty_string_param.php
+++ b/tests/fixtures/empty_string_param.php
@@ -1,0 +1,2 @@
+<?php
+$instructions = apply_filters( 'ai_assistant_ability_instructions', '', $ability_id, $arguments, $result );

--- a/tests/fixtures/expected/example_default_empty_string_param.md
+++ b/tests/fixtures/expected/example_default_empty_string_param.md
@@ -1,0 +1,19 @@
+## Auto-generated Example
+
+```php
+add_filter(
+   'ai_assistant_ability_instructions',
+    function(
+        string $value,
+        $ability_id,
+        $arguments,
+        $result
+    ) {
+        // Your code here.
+        return $value;
+    },
+    10,
+    4
+);
+```
+

--- a/tests/fixtures/expected/example_prefixed_empty_string_param.md
+++ b/tests/fixtures/expected/example_prefixed_empty_string_param.md
@@ -1,0 +1,19 @@
+## Auto-generated Example
+
+```php
+/**
+ * Callback function for the 'ai_assistant_ability_instructions' filter.
+ *
+ * @param string $value 
+ * @param mixed $ability_id 
+ * @param mixed $arguments 
+ * @param mixed $result 
+ * @return string The filtered value.
+ */
+function my_ai_assistant_ability_instructions_callback( string $value, $ability_id, $arguments, $result ) {
+    // Your code here.
+    return $value;
+}
+add_filter( 'ai_assistant_ability_instructions', 'my_ai_assistant_ability_instructions_callback', 10, 4 );
+```
+


### PR DESCRIPTION
## Summary

- An empty string `''` passed as a hook parameter produced `$` (bare dollar sign) as the variable name, resulting in invalid PHP like `string $,` and `return $;` in auto-generated examples
- Fixed by falling back to `$value` when the trimmed string content is empty
- Added tests and fixtures for both default and prefixed example styles

## Test plan

- [ ] Run `./vendor/bin/phpunit` — all 50 tests should pass
- [ ] Check `tests/fixtures/expected/example_default_empty_string_param.md` and `example_prefixed_empty_string_param.md` for valid PHP output