### PR TITLE
Add warnings for common hook documentation mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ It generates a markdown file for each filter which is suitable for a Github wiki
 ### Example: Provide Documentation Via a Comment
 For each filter, it looks at the comment preceeding the filter, so that you can document it, for example:
 
+> [!IMPORTANT]
+> You must use a PHPDoc comment (`/**`) — a regular block comment (`/*`) will not be parsed.
+
 ```php
-/*
+/**
  * This is example filter 1.
  *
  * @param string $text The text to modify.
@@ -64,7 +67,7 @@ But not only that, it will contain an auto-generated example:
 You can also provide your own example in the comment, that will override the auto-generated example:
 
 ```php
-/*
+/**
  * This is example filter 2.
  *
  * Example:

--- a/class-wphookextractor.php
+++ b/class-wphookextractor.php
@@ -186,7 +186,9 @@ class WpHookExtractor {
 
 				if ( $comment ) {
 					$docblock_param_count = preg_match_all( '/^\s*\*\s*@param\b/m', $comment );
-					if ( 0 === $docblock_param_count && empty( $hooks[ $hook ]['comment'] ) ) {
+					$hook_comment         = $hooks[ $hook ]['comment'] ?? '';
+
+					if ( 0 === $docblock_param_count && empty( $hook_comment ) ) {
 						$this->warnings[] = sprintf(
 							'%s:%d: Hook %s has an empty /** docblock (no description, no @param tags).',
 							$file_path,
@@ -202,6 +204,41 @@ class WpHookExtractor {
 							$docblock_param_count,
 							$actual_param_count
 						);
+					}
+
+					if ( $docblock_param_count > 0 && empty( $hook_comment ) ) {
+						$this->warnings[] = sprintf(
+							'%s:%d: Hook %s has @param tags but no description/title.',
+							$file_path,
+							$token[2],
+							$hook
+						);
+					}
+
+					if ( ! empty( $hook_comment ) ) {
+						$first_newline = strpos( $hook_comment, "\n" );
+						if ( false !== $first_newline && ( "\n" !== ( $hook_comment[ $first_newline + 1 ] ?? '' ) ) ) {
+							$this->warnings[] = sprintf(
+								'%s:%d: Hook %s title is not separated from the description by a blank line.',
+								$file_path,
+								$token[2],
+								$hook
+							);
+						}
+					}
+
+					if ( ! empty( $hooks[ $hook ]['examples'] ) ) {
+						foreach ( $hooks[ $hook ]['examples'] as $example ) {
+							if ( substr_count( $example['content'], '```' ) < 2 ) {
+								$this->warnings[] = sprintf(
+									'%s:%d: Hook %s has a malformed example (missing opening or closing ```php code fence).',
+									$file_path,
+									$token[2],
+									$hook
+								);
+								break;
+							}
+						}
 					}
 				}
 			}

--- a/class-wphookextractor.php
+++ b/class-wphookextractor.php
@@ -185,7 +185,7 @@ class WpHookExtractor {
 				$hooks[ $hook ]     = array_merge( $hooks[ $hook ], $this->parse_docblock( $comment, $hooks[ $hook ]['params'] ) );
 
 				if ( $comment ) {
-					$docblock_param_count = substr_count( $comment, '@param' );
+					$docblock_param_count = preg_match_all( '/^\s*\*\s*@param\b/m', $comment );
 					if ( 0 === $docblock_param_count && empty( $hooks[ $hook ]['comment'] ) ) {
 						$this->warnings[] = sprintf(
 							'%s:%d: Hook %s has an empty /** docblock (no description, no @param tags).',
@@ -193,7 +193,7 @@ class WpHookExtractor {
 							$token[2],
 							$hook
 						);
-					} elseif ( $docblock_param_count > 0 && $docblock_param_count < $actual_param_count ) {
+					} elseif ( $actual_param_count > 0 && $docblock_param_count !== $actual_param_count ) {
 						$this->warnings[] = sprintf(
 							'%s:%d: Hook %s has %d @param tag(s) in its docblock but %d parameter(s).',
 							$file_path,

--- a/class-wphookextractor.php
+++ b/class-wphookextractor.php
@@ -18,6 +18,13 @@ class WpHookExtractor {
 	private $config;
 
 	/**
+	 * Warnings collected during extraction.
+	 *
+	 * @var array
+	 */
+	private $warnings = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array $config Configuration options.
@@ -63,6 +70,7 @@ class WpHookExtractor {
 			$hook                    = false;
 			$l                       = max( 0, $i - 50 );
 			$found_significant_token = false;
+			$block_comment_line      = false;
 			for ( $j = $i; $j > $l; $j-- ) {
 				if ( ! is_array( $tokens[ $j ] ) ) {
 					continue;
@@ -78,6 +86,13 @@ class WpHookExtractor {
 					// Only use the comment if we haven't found any significant tokens between it and the hook.
 					if ( ! $found_significant_token ) {
 						$comment = $tokens[ $j ][1];
+					}
+					break;
+				}
+
+				if ( T_COMMENT === $tokens[ $j ][0] && str_starts_with( $tokens[ $j ][1], '/*' ) ) {
+					if ( ! $found_significant_token ) {
+						$block_comment_line = $tokens[ $j ][2];
 					}
 					break;
 				}
@@ -111,6 +126,15 @@ class WpHookExtractor {
 
 					break;
 				}
+			}
+
+			if ( $hook && $block_comment_line && ! $comment ) {
+				$this->warnings[] = sprintf(
+					'%s:%d: Hook %s has a /* block comment instead of a /** PHPDoc comment and will not be documented.',
+					$file_path,
+					$block_comment_line,
+					$hook
+				);
 			}
 
 			if (
@@ -157,7 +181,29 @@ class WpHookExtractor {
 					}
 				}
 
-				$hooks[ $hook ] = array_merge( $hooks[ $hook ], $this->parse_docblock( $comment, $hooks[ $hook ]['params'] ) );
+				$actual_param_count = count( $hooks[ $hook ]['params'] );
+				$hooks[ $hook ]     = array_merge( $hooks[ $hook ], $this->parse_docblock( $comment, $hooks[ $hook ]['params'] ) );
+
+				if ( $comment ) {
+					$docblock_param_count = substr_count( $comment, '@param' );
+					if ( 0 === $docblock_param_count && empty( $hooks[ $hook ]['comment'] ) ) {
+						$this->warnings[] = sprintf(
+							'%s:%d: Hook %s has an empty /** docblock (no description, no @param tags).',
+							$file_path,
+							$token[2],
+							$hook
+						);
+					} elseif ( $docblock_param_count > 0 && $docblock_param_count < $actual_param_count ) {
+						$this->warnings[] = sprintf(
+							'%s:%d: Hook %s has %d @param tag(s) in its docblock but %d parameter(s).',
+							$file_path,
+							$token[2],
+							$hook,
+							$docblock_param_count,
+							$actual_param_count
+						);
+					}
+				}
 			}
 		}
 
@@ -496,6 +542,15 @@ class WpHookExtractor {
 		}
 
 		return $hooks;
+	}
+
+	/**
+	 * Returns warnings collected during extraction.
+	 *
+	 * @return array List of warning strings.
+	 */
+	public function get_warnings() {
+		return $this->warnings;
 	}
 
 	/**

--- a/extract-wp-hooks.php
+++ b/extract-wp-hooks.php
@@ -56,4 +56,8 @@ $hooks = $extractor->scan_directory( $base );
 
 $extractor->generate_documentation( $hooks, $base . '/' . $config['wiki_directory'], $config['github_blob_url'] );
 
+foreach ( $extractor->get_warnings() as $warning ) {
+	fwrite( STDERR, 'Warning: ' . $warning . PHP_EOL );
+}
+
 echo 'Generated ' . count( $hooks ) . ' hooks documentation files in ' . realpath( $base . '/' . $config['wiki_directory'] ) . PHP_EOL;

--- a/extract-wp-hooks.php
+++ b/extract-wp-hooks.php
@@ -57,7 +57,7 @@ $hooks = $extractor->scan_directory( $base );
 $extractor->generate_documentation( $hooks, $base . '/' . $config['wiki_directory'], $config['github_blob_url'] );
 
 foreach ( $extractor->get_warnings() as $warning ) {
-	fwrite( STDERR, 'Warning: ' . $warning . PHP_EOL );
+	fwrite( STDERR, 'Warning: ' . $warning . PHP_EOL ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 }
 
 echo 'Generated ' . count( $hooks ) . ' hooks documentation files in ' . realpath( $base . '/' . $config['wiki_directory'] ) . PHP_EOL;

--- a/tests/WarningsTest.php
+++ b/tests/WarningsTest.php
@@ -76,6 +76,50 @@ class WarningsTest extends WpHookExtractor_Testcase {
 		$this->assertEmpty( $extractor->get_warnings() );
 	}
 
+	public function test_warning_for_no_title() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/no_title_docblock_hook.php' );
+
+		$warnings = $extractor->get_warnings();
+		$this->assertCount( 1, $warnings );
+		$this->assertStringContainsString( 'no_title_hook', $warnings[0] );
+		$this->assertStringContainsString( 'description', $warnings[0] );
+	}
+
+	public function test_warning_for_multiline_title() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/multiline_title_hook.php' );
+
+		$warnings = $extractor->get_warnings();
+		$this->assertCount( 1, $warnings );
+		$this->assertStringContainsString( 'multiline_title_hook', $warnings[0] );
+		$this->assertStringContainsString( 'blank line', $warnings[0] );
+	}
+
+	public function test_no_warning_for_proper_title_and_description() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/docblock_with_example.php' );
+
+		$this->assertEmpty( $extractor->get_warnings() );
+	}
+
+	public function test_warning_for_malformed_example() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/malformed_example_hook.php' );
+
+		$warnings = $extractor->get_warnings();
+		$this->assertCount( 1, $warnings );
+		$this->assertStringContainsString( 'malformed_example_hook', $warnings[0] );
+		$this->assertStringContainsString( 'malformed', $warnings[0] );
+	}
+
+	public function test_no_warning_for_well_formed_example() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/docblock_with_example.php' );
+
+		$this->assertEmpty( $extractor->get_warnings() );
+	}
+
 	public function test_warnings_cleared_between_files() {
 		$extractor = new WpHookExtractor();
 		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/block_comment_hook.php' );

--- a/tests/WarningsTest.php
+++ b/tests/WarningsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+class WarningsTest extends WpHookExtractor_Testcase {
+	public function test_no_warning_for_valid_docblock() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/simple_filter.php' );
+
+		$this->assertEmpty( $extractor->get_warnings() );
+	}
+
+	public function test_warning_for_block_comment_instead_of_phpdoc() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/block_comment_hook.php' );
+
+		$warnings = $extractor->get_warnings();
+		$this->assertCount( 1, $warnings );
+		$this->assertStringContainsString( 'block_comment_hook', $warnings[0] );
+		$this->assertStringContainsString( '/*', $warnings[0] );
+		$this->assertStringContainsString( '/**', $warnings[0] );
+	}
+
+	public function test_no_warning_when_no_comment_at_all() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/zero_params.php' );
+
+		$this->assertEmpty( $extractor->get_warnings() );
+	}
+
+	public function test_warning_for_empty_docblock() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/empty_docblock_hook.php' );
+
+		$warnings = $extractor->get_warnings();
+		$this->assertCount( 1, $warnings );
+		$this->assertStringContainsString( 'empty_docblock_hook', $warnings[0] );
+		$this->assertStringContainsString( 'empty', $warnings[0] );
+	}
+
+	public function test_warning_for_missing_param_tags() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/missing_params_docblock_hook.php' );
+
+		$warnings = $extractor->get_warnings();
+		$this->assertCount( 1, $warnings );
+		$this->assertStringContainsString( 'missing_params_hook', $warnings[0] );
+		$this->assertStringContainsString( '1', $warnings[0] );
+		$this->assertStringContainsString( '3', $warnings[0] );
+	}
+
+	public function test_no_warning_when_param_count_matches() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/two_params.php' );
+
+		$this->assertEmpty( $extractor->get_warnings() );
+	}
+
+	public function test_warnings_cleared_between_files() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/block_comment_hook.php' );
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/simple_filter.php' );
+
+		$warnings = $extractor->get_warnings();
+		$this->assertCount( 1, $warnings );
+	}
+}

--- a/tests/WarningsTest.php
+++ b/tests/WarningsTest.php
@@ -47,6 +47,28 @@ class WarningsTest extends WpHookExtractor_Testcase {
 		$this->assertStringContainsString( '3', $warnings[0] );
 	}
 
+	public function test_warning_for_extra_param_tags() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/extra_params_docblock_hook.php' );
+
+		$warnings = $extractor->get_warnings();
+		$this->assertCount( 1, $warnings );
+		$this->assertStringContainsString( 'extra_params_hook', $warnings[0] );
+		$this->assertStringContainsString( '3', $warnings[0] );
+		$this->assertStringContainsString( '2', $warnings[0] );
+	}
+
+	public function test_warning_for_description_only_docblock_with_params() {
+		$extractor = new WpHookExtractor();
+		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/description_only_docblock_hook.php' );
+
+		$warnings = $extractor->get_warnings();
+		$this->assertCount( 1, $warnings );
+		$this->assertStringContainsString( 'description_only_hook', $warnings[0] );
+		$this->assertStringContainsString( '0', $warnings[0] );
+		$this->assertStringContainsString( '2', $warnings[0] );
+	}
+
 	public function test_no_warning_when_param_count_matches() {
 		$extractor = new WpHookExtractor();
 		$extractor->extract_hooks_from_file( __DIR__ . '/fixtures/two_params.php' );

--- a/tests/fixtures/block_comment_hook.php
+++ b/tests/fixtures/block_comment_hook.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * This uses a block comment instead of a PHPDoc comment.
+ *
+ * @param string $value The value.
+ */
+$result = apply_filters( 'block_comment_hook', $value );

--- a/tests/fixtures/description_only_docblock_hook.php
+++ b/tests/fixtures/description_only_docblock_hook.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * A hook with a description but no parameter tags.
+ */
+$result = apply_filters( 'description_only_hook', $value, $extra );

--- a/tests/fixtures/empty_docblock_hook.php
+++ b/tests/fixtures/empty_docblock_hook.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ */
+$result = apply_filters( 'empty_docblock_hook', $value );

--- a/tests/fixtures/extra_params_docblock_hook.php
+++ b/tests/fixtures/extra_params_docblock_hook.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * A hook with more parameter tags than actual parameters.
+ *
+ * @param string $first  The first parameter.
+ * @param string $second The second parameter.
+ * @param string $third  A stale parameter that no longer exists.
+ */
+$result = apply_filters( 'extra_params_hook', $first, $second );

--- a/tests/fixtures/malformed_example_hook.php
+++ b/tests/fixtures/malformed_example_hook.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * A hook with a malformed example.
+ *
+ * Example:
+ * add_filter( 'malformed_example_hook', function( $value ) {
+ *     return $value;
+ * } );
+ *
+ * @param string $value The value.
+ */
+$result = apply_filters( 'malformed_example_hook', $value );

--- a/tests/fixtures/missing_params_docblock_hook.php
+++ b/tests/fixtures/missing_params_docblock_hook.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * A hook with fewer parameter tags than actual parameters.
+ *
+ * @param string $first The first parameter.
+ */
+$result = apply_filters( 'missing_params_hook', $first, $second, $third );

--- a/tests/fixtures/multiline_title_hook.php
+++ b/tests/fixtures/multiline_title_hook.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * This is the first line of the title.
+ * This is the second line without a blank separator.
+ *
+ * @param string $value The value.
+ */
+$result = apply_filters( 'multiline_title_hook', $value );

--- a/tests/fixtures/no_title_docblock_hook.php
+++ b/tests/fixtures/no_title_docblock_hook.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @param string $value The value.
+ * @param int    $count The count.
+ */
+$result = apply_filters( 'no_title_hook', $value, $count );


### PR DESCRIPTION
## Summary

Adds a `$warnings` array and `get_warnings()` method to `WpHookExtractor`. Warnings are written to stderr by `extract-wp-hooks.php` after scanning.

Six warnings are collected during extraction:

- `/*` block comment instead of `/**` — hook is extracted but the comment is silently ignored
- Empty `/**` docblock — no description and no `@param` tags
- `@param` tags but no description/title — nothing will appear next to the hook in the index
- Title not separated from description by a blank line — the first line is used as the index entry so it needs to stand alone
- Mismatch between `@param` tag count and actual parameter count — catches both too few and too many
- Malformed example block — missing opening or closing ` ```php ` code fence

Uses a line-anchored regex (`/^\s*\*\s*@param\b/m`) to count `@param` tags so occurrences in description text are not counted.

14 new tests covering all warning cases and happy paths.

## Test plan

- [ ] `./vendor/bin/phpunit` — all 64 tests pass
- [ ] `./vendor/bin/phpcs --standard=phpcs.xml class-wphookextractor.php extract-wp-hooks.php` — no errors