### PR TITLE
Fix wiki output path for subdirectory scans

### DIFF
--- a/extract-wp-hooks.php
+++ b/extract-wp-hooks.php
@@ -54,10 +54,15 @@ echo 'Scanning ', $base, PHP_EOL;
 $extractor = new WpHookExtractor( $config );
 $hooks = $extractor->scan_directory( $base );
 
-$extractor->generate_documentation( $hooks, $base . '/' . $config['wiki_directory'], $config['github_blob_url'] );
+$wiki_directory = $config['wiki_directory'];
+if ( '/' !== substr( $wiki_directory, 0, 1 ) ) {
+	$wiki_directory = getcwd() . '/' . $wiki_directory;
+}
+
+$extractor->generate_documentation( $hooks, $wiki_directory, $config['github_blob_url'] );
 
 foreach ( $extractor->get_warnings() as $warning ) {
 	fwrite( STDERR, 'Warning: ' . $warning . PHP_EOL ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 }
 
-echo 'Generated ' . count( $hooks ) . ' hooks documentation files in ' . realpath( $base . '/' . $config['wiki_directory'] ) . PHP_EOL;
+echo 'Generated ' . count( $hooks ) . ' hooks documentation files in ' . realpath( $wiki_directory ) . PHP_EOL;

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -1,0 +1,63 @@
+<?php
+
+class CliTest extends WpHookExtractor_Testcase {
+	private $temp_dirs = array();
+
+	public function tearDown(): void {
+		foreach ( $this->temp_dirs as $dir ) {
+			$this->remove_dir( $dir );
+		}
+	}
+
+	public function test_wiki_directory_is_relative_to_project_root_when_base_dir_is_subdirectory() {
+		$project_dir = $this->make_temp_dir();
+		mkdir( $project_dir . '/src', 0777, true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+
+		copy( __DIR__ . '/fixtures/zero_params.php', $project_dir . '/src/hooks.php' );
+		$config_json = json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+			array(
+				'base_dir'        => 'src',
+				'wiki_directory'  => 'wiki',
+				'github_blob_url' => 'https://github.com/test/repo/blob/main/',
+			)
+		);
+		file_put_contents( $project_dir . '/.extract-wp-hooks.json', $config_json ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		$cwd = getcwd();
+		chdir( $project_dir );
+		exec( escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( __DIR__ . '/../extract-wp-hooks.php' ) . ' 2>&1', $output, $exit_code ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		chdir( $cwd );
+
+		$this->assertSame( 0, $exit_code, implode( PHP_EOL, $output ) );
+		$this->assertFileExists( $project_dir . '/wiki/zero_param_hook.md' );
+		$this->assertFileDoesNotExist( $project_dir . '/src/wiki/zero_param_hook.md' );
+	}
+
+	private function make_temp_dir() {
+		$dir = sys_get_temp_dir() . '/extract-wp-hooks-' . uniqid();
+		mkdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		$this->temp_dirs[] = $dir;
+		return $dir;
+	}
+
+	private function remove_dir( $dir ) {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $dir, FilesystemIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+
+		foreach ( $iterator as $path ) {
+			if ( $path->isDir() ) {
+				rmdir( $path->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+			} else {
+				unlink( $path->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+			}
+		}
+
+		rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+	}
+}


### PR DESCRIPTION
## Summary
- Resolve wiki_directory relative to the project root/current working directory instead of base_dir
- Add a CLI regression test for base_dir=src with wiki_directory=wiki

Fixes #34

## Testing
- composer test
- composer phpcs